### PR TITLE
Updated sonda process: move to front controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix sonda resolution when order status new after payment approved has shipped flag enable
+
 ## [3.7.0 (2022-07-07)](https://github.com/placetopay/prestashop-placetopay/compare/3.6.5...3.7.0)
 
 ### Added

--- a/controllers/front/sonda.php
+++ b/controllers/front/sonda.php
@@ -1,0 +1,17 @@
+<?php
+
+// @see https://devdocs.prestashop.com/1.7/development/architecture/legacy/legacy-controllers/
+// @see https://devdocs.prestashop.com/1.7/modules/concepts/controllers/front-controllers/#using-a-front-controller-as-a-cron-task
+class PlacetoPayPaymentSondaModuleFrontController extends ModuleFrontController
+{
+    public $auth = false;
+
+    public function display()
+    {
+        if (!isConsole()) {
+            Tools::redirect('index');
+        }
+
+        resolvePendingPaymentsPlacetoPay();
+    }
+}

--- a/helpers.php
+++ b/helpers.php
@@ -54,7 +54,7 @@ if (!function_exists('isConsole')) {
         static $isConsole;
 
         if (is_null($isConsole)) {
-            $isConsole = 'cli' == php_sapi_name();
+            $isConsole = \Tools::isPHPCLI();
         }
 
         return $isConsole;

--- a/sonda.php
+++ b/sonda.php
@@ -1,41 +1,34 @@
 <?php
 /**
- * Payments pending
+ * Pending payments
  */
 
 use PlacetoPay\Loggers\PaymentLogger;
 
-try {
-    require_once 'helpers.php';
+require_once 'helpers.php';
 
-    $pathCMS = getPathCMS('sonda.php');
+$_SERVER['REQUEST_METHOD'] = 'POST';
 
-    require fixPath($pathCMS . '/config/config.inc.php');
-    require fixPath(sprintf('%s/%2$s/%2$s.php', _PS_MODULE_DIR_, getModuleName()));
+$_GET['fc'] = 'module';
+$_GET['module'] = getModuleName();
+$_GET['controller'] = 'sonda';
 
-    $pathKernel =  _PS_ROOT_DIR_ . '/app/AppKernel.php';
+require_once dirname(__FILE__) . '/../../index.php';
 
-    global $kernel;
+function resolvePendingPaymentsPlacetoPay() {
+    try {
+        if (isDebugEnable()) {
+            PaymentLogger::log('Starting Resolve Pending Payments', PaymentLogger::DEBUG, 0, __FILE__, __LINE__);
+        }
 
-    if(!$kernel && is_file($pathKernel)){
-        // PS >= 1.7
-        require_once $pathKernel;
+        (new PlacetoPayPayment())->resolvePendingPayments();
 
-        $kernel = new \AppKernel('prod', false);
-        $kernel->boot();
+        if (isDebugEnable()) {
+            PaymentLogger::log('Finished Resolve Pending Payments', PaymentLogger::DEBUG, 0, __FILE__, __LINE__);
+        }
+    } catch (Throwable $exception) {
+        PaymentLogger::log($exception->getMessage(), PaymentLogger::ERROR, 999, __FILE__, __LINE__);
+
+        die($exception->getMessage());
     }
-
-    if (isDebugEnable()) {
-        PaymentLogger::log('Starting Resolve Pending Payments', PaymentLogger::DEBUG, 0, __FILE__, __LINE__);
-    }
-
-    (new PlacetoPayPayment())->resolvePendingPayments();
-
-    if (isDebugEnable()) {
-        PaymentLogger::log('Finished Resolve Pending Payments', PaymentLogger::DEBUG, 0, __FILE__, __LINE__);
-    }
-} catch (Exception $e) {
-    PaymentLogger::log($e->getMessage(), PaymentLogger::ERROR, 999, __FILE__, __LINE__);
-
-    die($e->getMessage());
 }

--- a/src/Models/PlacetoPayPayment.php
+++ b/src/Models/PlacetoPayPayment.php
@@ -111,7 +111,7 @@ class PlacetoPayPayment extends PaymentModule
     const PAGE_HOME = '';
 
     const MIN_VERSION_PS = '1.6.1.0';
-    const MAX_VERSION_PS = '1.7.8.6';
+    const MAX_VERSION_PS = '1.7.8.7';
 
     /**
      * @var string
@@ -126,7 +126,7 @@ class PlacetoPayPayment extends PaymentModule
     public function __construct()
     {
         $this->name = getModuleName();
-        $this->version = '3.7.0';
+        $this->version = '3.7.1';
 
         $this->tab = 'payments_gateways';
 


### PR DESCRIPTION
This movement avoid context errors like:

- Error: Determining the active language requires a contextual employee instance.
- Error: Shop context types other than 'single shop' are not supported

This process are triggered from StockMovement when order status has enable shipped flag